### PR TITLE
Fix static assets when serving app through subpath proxy

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { withBasePath } from '../lib/utils'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -8,7 +9,7 @@ export const metadata: Metadata = {
   title: 'Bitcoin Grants Common Application',
   description: 'A unified platform for applying to Bitcoin-related grants across multiple organizations.',
   icons: {
-    icon: '/favicon.ico',
+    icon: withBasePath('/favicon.ico'),
   },
   keywords: ['Bitcoin', 'grants', 'funding', 'cryptocurrency', 'open source', 'OpenSats', 'Brink', 'Btrust', 'Maelstrom', 'Spiral'],
   authors: [{ name: 'Bitcoin Grants Common Application' }],

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,37 +7,38 @@ import FeaturedOrg from '../components/FeaturedOrg'
 import ProcessStep from '../components/ProcessStep'
 import FaqAccordion from '../components/FaqAccordion'
 import Footer from '../components/Footer'
+import { withBasePath } from '../lib/utils'
 
 export default function Home() {
   // Organization data
   const organizations = [
     {
       name: "OpenSats",
-      logo: "/logos/opensats.png",
+      logo: withBasePath("/logos/opensats.png"),
       description: "Supporting open source Bitcoin development and education through sustainable funding models.",
       accentColor: "bg-orange-500",
     },
     {
       name: "Btrust",
-      logo: "/logos/btrust.jpg",
+      logo: withBasePath("/logos/btrust.jpg"),
       description: "Advancing Bitcoin development throughout Africa and beyond, focusing on self-sovereignty.",
       accentColor: "bg-blue-600",
     },
     {
       name: "Brink",
-      logo: "/logos/brink.png",
+      logo: withBasePath("/logos/brink.png"),
       description: "Supporting Bitcoin protocol developers and research to strengthen the Bitcoin network.",
       accentColor: "bg-purple-600",
     },
     {
       name: "Maelstrom",
-      logo: "/logos/maelstrom.png",
+      logo: withBasePath("/logos/maelstrom.png"),
       description: "Supporting Bitcoin developers to enhance Bitcoin's resilience, scalability, censorship resistance and privacy.",
       accentColor: "bg-blue-600",
     },
     {
       name: "Spiral",
-      logo: "/logos/spiral.svg",
+      logo: withBasePath("/logos/spiral.svg"),
       description: "Making bitcoin more than an investment through FOSS Bitcoin Grants for developers and designers.",
       accentColor: "bg-yellow-600",
     },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,12 @@
+/**
+ * Utility function to add base path prefix to URLs
+ * This ensures assets and routes work correctly when the app is served under a subpath
+ */
+export function withBasePath(path: string): string {
+  const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+  // Don't add basePath if it's already included or if path is external
+  if (path.startsWith('http') || path.startsWith(basePath)) {
+    return path;
+  }
+  return `${basePath}${path}`;
+} 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Configure base path based on environment
+  // When deployed standalone, no basePath needed
+  // When served through main site, use /grants basePath
+  basePath: process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_BASE_PATH ? process.env.NEXT_PUBLIC_BASE_PATH : '',
+  assetPrefix: process.env.NODE_ENV === 'production' && process.env.NEXT_PUBLIC_BASE_PATH ? process.env.NEXT_PUBLIC_BASE_PATH : '',
   // Ensures Tailwind CSS works properly
   experimental: {
     optimizeCss: true


### PR DESCRIPTION
When serving the grants app through the main site proxy at `https://bitcoindevs.xyz/grants`, all static assets (CSS, JS, images) were returning 404 errors because they were being requested from the root path instead of the subpath.

This PR fixes this