### PR TITLE
Make organisation "learn more" links work on cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,24 @@ import { withAssetPrefix } from '../lib/utils'
 import organizationsConfig from '../config/organizations'
 
 export default function Home() {
+  // Map organization data with display properties
+  const accentColors: Record<string, string> = {
+    opensats: "bg-orange-500",
+    btrust: "bg-blue-600",
+    brink: "bg-purple-600",
+    maelstrom: "bg-blue-600",
+    spiral: "bg-yellow-600"
+  };
+
+  const organizations = Object.values(organizationsConfig)
+    .filter(org => org.active)
+    .map(org => ({
+      name: org.name,
+      logo: withAssetPrefix(org.logo || ''),
+      description: org.description,
+      accentColor: accentColors[org.id] || "bg-gray-600",
+      url: org.website
+    }));
 
   const processSteps = [
     {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,41 +8,9 @@ import ProcessStep from '../components/ProcessStep'
 import FaqAccordion from '../components/FaqAccordion'
 import Footer from '../components/Footer'
 import { withAssetPrefix } from '../lib/utils'
+import organizationsConfig from '../config/organizations'
 
 export default function Home() {
-  // Organization data
-  const organizations = [
-    {
-      name: "OpenSats",
-      logo: withAssetPrefix("/logos/opensats.png"),
-      description: "Supporting open source Bitcoin development and education through sustainable funding models.",
-      accentColor: "bg-orange-500",
-    },
-    {
-      name: "Btrust",
-      logo: withAssetPrefix("/logos/btrust.png"),
-      description: "Advancing Bitcoin development throughout Africa and beyond, focusing on self-sovereignty.",
-      accentColor: "bg-blue-600",
-    },
-    {
-      name: "Brink",
-      logo: withAssetPrefix("/logos/brink.png"),
-      description: "Supporting Bitcoin protocol developers and research to strengthen the Bitcoin network.",
-      accentColor: "bg-purple-600",
-    },
-    {
-      name: "Maelstrom",
-      logo: withAssetPrefix("/logos/maelstrom.png"),
-      description: "Supporting Bitcoin developers to enhance Bitcoin's resilience, scalability, censorship resistance and privacy.",
-      accentColor: "bg-blue-600",
-    },
-    {
-      name: "Spiral",
-      logo: withAssetPrefix("/logos/spiral.svg"),
-      description: "Making Bitcoin more than an investment through FOSS Bitcoin Grants for developers and designers.",
-      accentColor: "bg-yellow-600",
-    },
-  ];
 
   const processSteps = [
     {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,6 +88,7 @@ export default function Home() {
                 logo={org.logo} 
                 description={org.description} 
                 accentColor={org.accentColor}
+                url={org.url}
               />
             ))}
           </div>
@@ -99,6 +100,7 @@ export default function Home() {
                 logo={org.logo} 
                 description={org.description} 
                 accentColor={org.accentColor}
+                url={org.url}
               />
             ))}
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,21 +12,13 @@ import organizationsConfig from '../config/organizations'
 
 export default function Home() {
   // Map organization data with display properties
-  const accentColors: Record<string, string> = {
-    opensats: "bg-orange-500",
-    btrust: "bg-blue-600",
-    brink: "bg-purple-600",
-    maelstrom: "bg-blue-600",
-    spiral: "bg-yellow-600"
-  };
-
   const organizations = Object.values(organizationsConfig)
     .filter(org => org.active)
     .map(org => ({
       name: org.name,
       logo: withAssetPrefix(org.logo || ''),
       description: org.description,
-      accentColor: accentColors[org.id] || "bg-gray-600",
+      accentColor: org.accentColor || "bg-gray-600",
       url: org.website
     }));
 

--- a/components/FeaturedOrg.tsx
+++ b/components/FeaturedOrg.tsx
@@ -8,9 +8,10 @@ type FeaturedOrgProps = {
   logo: string
   description: string
   accentColor: string
+  url?: string
 }
 
-export default function FeaturedOrg({ name, logo, description, accentColor }: FeaturedOrgProps) {
+export default function FeaturedOrg({ name, logo, description, accentColor, url }: FeaturedOrgProps) {
   const [isHovered, setIsHovered] = useState(false)
   
   return (

--- a/components/FeaturedOrg.tsx
+++ b/components/FeaturedOrg.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image'
 import { useState } from 'react'
+import SmartLink from './SmartLink'
 
 type FeaturedOrgProps = {
   name: string
@@ -49,14 +50,21 @@ export default function FeaturedOrg({ name, logo, description, accentColor, url 
         
         <p className="text-gray-600 text-sm leading-relaxed">{description}</p>
         
-        <div className={`mt-4 sm:mt-6 pt-3 sm:pt-4 border-t border-gray-100 flex justify-between items-center transition-opacity duration-300 ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
-          <span className="text-xs sm:text-sm font-medium text-gray-500">Learn more</span>
-          <div className={`w-6 h-6 sm:w-8 sm:h-8 rounded-full ${accentColor} flex items-center justify-center`}>
-            <svg className="w-3 h-3 sm:w-4 sm:h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </div>
-        </div>
+        {url && (
+          <SmartLink
+            href={url}
+            className={`mt-4 sm:mt-6 pt-3 sm:pt-4 border-t border-gray-100 flex justify-between items-center transition-opacity duration-300 ${isHovered ? 'opacity-100' : 'opacity-0'} hover:no-underline`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span className="text-xs sm:text-sm font-medium text-gray-500 hover:text-gray-700 transition-colors">Learn more</span>
+            <div className={`w-6 h-6 sm:w-8 sm:h-8 rounded-full ${accentColor} flex items-center justify-center transform transition-transform hover:scale-110`}>
+              <svg className="w-3 h-3 sm:w-4 sm:h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </div>
+          </SmartLink>
+        )}
       </div>
     </div>
   )

--- a/config/organizations.ts
+++ b/config/organizations.ts
@@ -4,6 +4,7 @@ export type Organization = {
   description: string;
   website: string;
   logo?: string;
+  accentColor?: string;
   apiUrl?: string;
   active: boolean;
   workflowImplemented?: boolean;
@@ -34,6 +35,7 @@ const organizations: Record<string, Organization> = {
     description: 'OpenSats is a nonprofit organization dedicated to supporting open-source Bitcoin and other free and open-source software projects.',
     website: 'https://opensats.org',
     logo: '/logos/opensats.png',
+    accentColor: 'bg-orange-500',
     // apiUrl: process.env.OPENSATS_API_URL || 'https://opensats.org/api/github',
     apiUrl: process.env.OPENSATS_API_URL,
     active: true,
@@ -59,6 +61,7 @@ const organizations: Record<string, Organization> = {
     description: 'Brink empowers Bitcoin developers and researchers through funding, education, and mentoring.',
     website: 'https://brink.dev',
     logo: '/logos/brink.png',
+    accentColor: 'bg-purple-600',
     active: true,
     workflowImplemented: true,
     workflowType: 'email',
@@ -88,6 +91,7 @@ const organizations: Record<string, Organization> = {
     description: 'Btrust is a Bitcoin-focused trust dedicated to funding Bitcoin development and education throughout Africa and beyond.',
     website: 'https://btrust.tech',
     logo: '/logos/btrust.png',
+    accentColor: 'bg-blue-600',
     active: true,
     workflowImplemented: true,
     workflowType: 'email',
@@ -122,6 +126,7 @@ const organizations: Record<string, Organization> = {
     description: 'Maelstrom supports Bitcoin developers working on tools and technologies that enhance Bitcoin\'s resilience, scalability, censorship resistance and privacy characteristics.',
     website: 'https://maelstrom.fund/bitcoin-grant-program/',
     logo: '/logos/maelstrom.png',
+    accentColor: 'bg-blue-600',
     active: true,
     workflowImplemented: true,
     workflowType: 'email',
@@ -149,6 +154,7 @@ const organizations: Record<string, Organization> = {
     description: 'Spiral is a team funded by Block that supports Bitcoin development through their FOSS Bitcoin Grants program.',
     website: 'https://spiral.xyz',
     logo: '/logos/spiral.svg',
+    accentColor: 'bg-yellow-600',
     active: true,
     workflowImplemented: true,
     workflowType: 'email',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/**/*.{js,ts,jsx,tsx,mdx}',
+    './config/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
These changes address the following:

- The FeaturedOrg component shows "Learn more" text but isn't clickable 
- Organization data is duplicated in `app/page.tsx` instead of using the centralized config - `config/organizations.ts` already has website URLs for each organization!
- Other organization data also moved into centralized config, e.g. accent colours