### PR TITLE
fix: layout spacing fixed

### DIFF
--- a/components/FaqAccordion.tsx
+++ b/components/FaqAccordion.tsx
@@ -118,7 +118,7 @@ export default function FaqAccordion() {
   ]
 
   return (
-    <div className="mx-auto w-full max-w-3xl divide-y divide-gray-200 rounded-2xl bg-white p-2 gradient-border">
+    <div className="mx-auto w-full max-w-3xl divide-y divide-gray-200 rounded-2xl bg-white p-6 sm:p-8 gradient-border">
       <h2 className="p-4 sm:p-6 text-xl sm:text-2xl font-extrabold text-center text-gray-900">
         Frequently Asked Questions
       </h2>


### PR DESCRIPTION
This PR improves the layout of the FAQ section by increasing the padding inside the FAQ container. This ensures there is adequate space between the yellow gradient border and the FAQ content.

**Issue Fixed**
Issue #26 

**Changes:**

- Increased the padding on the FAQ container (p-6 sm:p-8).
- Ensured the FAQ content no longer appears too close to the border.

**Before**

<img width="1835" height="937" alt="Screenshot from 2026-01-28 18-22-57" src="https://github.com/user-attachments/assets/aa28b004-a40e-4e33-b314-766c872ab1c0" />

<img width="384" height="791" alt="Screenshot from 2026-01-28 18-23-33" src="https://github.com/user-attachments/assets/5d59fdff-d7a8-4352-b680-0ab799c95837" />

**After**
<img width="1836" height="986" alt="Screenshot from 2026-01-28 18-23-59" src="https://github.com/user-attachments/assets/2558aea3-69bf-4a7e-98c7-74253c44ee91" />

<img width="387" height="784" alt="Screenshot from 2026-01-28 18-24-22" src="https://github.com/user-attachments/assets/680f5801-7fc6-447b-8743-aa14079be6cb" />
